### PR TITLE
Add ability to deny partner supplier access

### DIFF
--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -44,9 +44,15 @@ export class AdminController {
   }
 
   @UseGuards(AdminGuard)
-  @Put('pending/:id')
-  async toggleAccessPending(@Param('id') id: string) {
-    return await this.adminService.toggleAccessPending(id);
+  @Patch('approve-partner/:id')
+  async approvePartnerSupplier(@Param('id') id: string) {
+    return await this.adminService.approvePartnerSupplier(id);
+  }
+
+  @UseGuards(AdminGuard)
+  @Patch('reject-partner/:id')
+  async rejectPartnerSupplier(@Param('id') id: string) {
+    return await this.adminService.rejectPartnerSupplier(id);
   }
 
   @UseGuards(AdminGuard)

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -38,10 +38,18 @@ export class AuthService {
       return null;
     }
 
-    if (user.partnerSupplier && user.partnerSupplier.accessPending) {
-      throw new ForbiddenException(
-        'Cadastro pendente de aprovação. \nVocê receberá um email assim que o processo for concluído.',
-      );
+    if (user.partnerSupplier) {
+      if (user.partnerSupplier.status === 'PENDING') {
+        throw new ForbiddenException(
+          'Cadastro pendente de aprovação. \nVocê receberá um email assim que o processo for concluído.',
+        );
+      }
+
+      if (user.partnerSupplier.status === 'REJECTED') {
+        throw new ForbiddenException(
+          'Seu cadastro foi reprovado. Entre em contato com o suporte para mais informações.',
+        );
+      }
     }
 
     const isPasswordValid = await bcrypt.compare(password, user.password);

--- a/src/partner-supplier/dto/create-partner-supplier.dto.ts
+++ b/src/partner-supplier/dto/create-partner-supplier.dto.ts
@@ -1,4 +1,4 @@
-import { IsBoolean, IsOptional, IsString } from 'class-validator';
+import { IsOptional, IsString } from 'class-validator';
 
 export class CreatePartnerSupplierDto {
   @IsString()
@@ -22,7 +22,4 @@ export class CreatePartnerSupplierDto {
   @IsString()
   profileImage?: string;
 
-  @IsOptional()
-  @IsBoolean()
-  accessPending?: boolean;
 }

--- a/src/partner-supplier/partner-supplier.service.ts
+++ b/src/partner-supplier/partner-supplier.service.ts
@@ -63,7 +63,7 @@ export class PartnerSupplierService {
   async findAll() {
     return this.prisma.partnerSupplier.findMany({
       where: {
-        accessPending: false,
+        status: 'APPROVED',
       },
       include: {
         store: {
@@ -95,7 +95,7 @@ export class PartnerSupplierService {
           not: null,
         },
         partnerSupplier: {
-          accessPending: true,
+          status: 'PENDING',
         },
       },
       include: {

--- a/src/prisma/migrations/20251122000000_add_registration_status/migration.sql
+++ b/src/prisma/migrations/20251122000000_add_registration_status/migration.sql
@@ -1,0 +1,11 @@
+-- CreateEnum
+CREATE TYPE "RegistrationStatus" AS ENUM ('PENDING', 'APPROVED', 'REJECTED');
+
+-- AlterTable
+ALTER TABLE "PartnerSupplier" ADD COLUMN "status" "RegistrationStatus" NOT NULL DEFAULT 'PENDING';
+
+-- UpdateStatus
+UPDATE "PartnerSupplier" SET "status" = 'APPROVED' WHERE "accessPending" = false;
+
+-- AlterTable
+ALTER TABLE "PartnerSupplier" DROP COLUMN "accessPending";

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -71,7 +71,7 @@ model PartnerSupplier {
   stateRegistration String?
   contact           String?
 
-  accessPending Boolean @default(true)
+  status RegistrationStatus @default(PENDING)
 
   user         User?         @relation("UserPartner")
   store        Store?
@@ -459,4 +459,10 @@ enum RedemptionStatus {
   USED
   EXPIRED
   CANCELED
+}
+
+enum RegistrationStatus {
+  PENDING
+  APPROVED
+  REJECTED
 }


### PR DESCRIPTION
Implemented the ability to deny access to partner suppliers in the admin module.
Key changes:
- Database schema update: added RegistrationStatus enum and replaced accessPending boolean with status.
- Admin endpoints: added PATCH /admin/approve-partner/:id and PATCH /admin/reject-partner/:id.
- Authentication: users with REJECTED status are now blocked from logging in with a specific message.
- Emails: specific emails are sent for both approval and rejection.
- Service logic: updated filters to use the new status field.

---
*PR created automatically by Jules for task [16518215272171373756](https://jules.google.com/task/16518215272171373756) started by @higoruserevi*