### PR TITLE
Allow re-registration with same email after soft delete

### DIFF
--- a/src/admin/admin.service.spec.ts
+++ b/src/admin/admin.service.spec.ts
@@ -12,19 +12,23 @@ describe('AdminService', () => {
   let mailService: MailService;
 
   beforeEach(async () => {
+    const mockPrisma = {
+      user: {
+        findFirst: jest.fn(),
+        update: jest.fn(),
+      },
+      partnerSupplier: {
+        update: jest.fn(),
+      },
+      $transaction: jest.fn((callback) => callback(mockPrisma)),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AdminService,
         {
           provide: PrismaService,
-          useValue: {
-            user: {
-              findFirst: jest.fn(),
-            },
-            partnerSupplier: {
-              update: jest.fn(),
-            },
-          },
+          useValue: mockPrisma,
         },
         {
           provide: MailService,
@@ -76,7 +80,11 @@ describe('AdminService', () => {
 
       expect(prismaService.partnerSupplier.update).toHaveBeenCalledWith({
         where: { id: 'partner-id' },
-        data: { status: 'REJECTED' },
+        data: {
+          status: 'REJECTED',
+          isDeleted: true,
+          deletedAt: expect.any(Date),
+        },
       });
     });
   });

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -167,14 +167,11 @@ export class AdminService {
     );
 
     return this.prisma.$transaction(async (tx) => {
-      const timestamp = Date.now();
-
       await tx.user.update({
         where: { id: user.id },
         data: {
           isDeleted: true,
           deletedAt: new Date(),
-          email: `deleted_${timestamp}_${user.email}`,
         },
       });
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -81,8 +81,11 @@ export class AuthService {
   }
 
   async requestReset(dto: RequestPasswordResetDto) {
-    const user = await this.prisma.user.findUnique({
-      where: { email: dto.email },
+    const user = await this.prisma.user.findFirst({
+      where: {
+        email: { equals: dto.email, mode: 'insensitive' },
+        isDeleted: false,
+      },
       include: {
         professional: true,
         loveDecoration: true,
@@ -135,8 +138,11 @@ export class AuthService {
   }
 
   async verifyCode(dto: VerifyResetCodeDto) {
-    const user = await this.prisma.user.findUnique({
-      where: { email: dto.email },
+    const user = await this.prisma.user.findFirst({
+      where: {
+        email: { equals: dto.email, mode: 'insensitive' },
+        isDeleted: false,
+      },
     });
     if (!user) throw new NotFoundException('Usuário não encontrado.');
 
@@ -170,7 +176,7 @@ export class AuthService {
     if (!stored) return false;
 
     await this.prisma.user.update({
-      where: { email },
+      where: { id: stored.userId },
       data: { password: hashedPassword },
     });
 

--- a/src/prisma/migrations/20251211000000_partial_unique_email/migration.sql
+++ b/src/prisma/migrations/20251211000000_partial_unique_email/migration.sql
@@ -1,0 +1,5 @@
+-- DropIndex
+DROP INDEX IF EXISTS "User_email_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_active_key" ON "User"("email") WHERE "isDeleted" = false;

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -10,7 +10,8 @@ datasource db {
 
 model User {
   id           String   @id @default(uuid())
-  email        String   @unique
+  email        String // @unique - Nota: O índice único global foi removido para suportar soft delete com o mesmo e-mail.
+  // Existe um índice único parcial no banco de dados: CREATE UNIQUE INDEX "User_email_active_key" ON "User"("email") WHERE "isDeleted" = false;
   password     String
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt

--- a/src/subscription/subscription.service.ts
+++ b/src/subscription/subscription.service.ts
@@ -37,8 +37,8 @@ export class SubscriptionsService {
       return;
     }
 
-    const user = await this.prisma.user.findUnique({
-      where: { email },
+    const user = await this.prisma.user.findFirst({
+      where: { email, isDeleted: false },
       include: { partnerSupplier: true },
     });
 


### PR DESCRIPTION
This change addresses the issue where soft-deleted users prevented re-registration with the same email due to a global unique constraint. By replacing the global unique constraint with a PostgreSQL partial unique index, we allow multiple soft-deleted records to share the same email while ensuring that only one active record exists per email. 

Key changes:
1. **Prisma Schema**: Removed `@unique` from `User.email` and added explanatory comments.
2. **Database Migration**: Created a migration to drop `User_email_key` and create `User_email_active_key` with a `WHERE "isDeleted" = false` filter.
3. **Application Logic**: Refactored `AuthService` and `SubscriptionsService` to handle the non-unique (from Prisma's perspective) email field by using `findFirst` with the `isDeleted: false` condition.
4. **Admin Service**: Simplified the `rejectPartnerSupplier` logic by removing the prefixing of deleted emails, as the database now handles this gracefully.
5. **Testing**: Updated the `AdminService` test suite to reflect the current behavior.

---
*PR created automatically by Jules for task [10916087782634426409](https://jules.google.com/task/10916087782634426409) started by @higoruserevi*