### PR TITLE
Melhorias no Gerenciamento de Trial e Visibilidade de Dados Admin

### DIFF
--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -197,4 +197,10 @@ export class AdminController {
   async grantTrial(@Param('id') id: string, @Body() dto: GrantTrialDto) {
     return await this.adminService.grantTrial(id, dto);
   }
+
+  @UseGuards(AdminGuard)
+  @Patch('cancel-trial/:id')
+  async cancelTrial(@Param('id') id: string) {
+    return await this.adminService.cancelManualSubscription(id);
+  }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -28,7 +28,9 @@ export class AuthService {
         isDeleted: false,
       },
       include: {
-        partnerSupplier: true,
+        partnerSupplier: {
+          include: { subscription: true },
+        },
         professional: {
           include: { profession: true },
         },

--- a/src/store/store.service.ts
+++ b/src/store/store.service.ts
@@ -115,6 +115,11 @@ export class StoreService {
             date: 'asc',
           },
         },
+        partner: {
+          include: {
+            subscription: true,
+          },
+        },
       },
     });
   }
@@ -133,7 +138,7 @@ export class StoreService {
           s."addressId",
           s."partnerId",
           CASE
-            WHEN sub.id IS NOT NULL AND (sub."subscriptionStatus" = 'ACTIVE' OR sub."subscriptionStatus" = 'TRIALING') AND sub."currentPeriodEnd" >= NOW() THEN
+            WHEN sub.id IS NOT NULL AND (sub."subscriptionStatus" = 'ACTIVE' OR sub."subscriptionStatus" = 'TRIALING') AND (sub."currentPeriodEnd" >= NOW() OR sub."isManual" = true) THEN
               CASE
                 WHEN sub."planType" = 'PREMIUM' THEN 3
                 WHEN sub."planType" = 'GOLD' THEN 2
@@ -145,7 +150,7 @@ export class StoreService {
           ROW_NUMBER() OVER (
           ORDER BY 
             CASE 
-              WHEN sub.id IS NOT NULL AND (sub."subscriptionStatus" = 'ACTIVE' OR sub."subscriptionStatus" = 'TRIALING') AND sub."currentPeriodEnd" >= NOW() THEN
+              WHEN sub.id IS NOT NULL AND (sub."subscriptionStatus" = 'ACTIVE' OR sub."subscriptionStatus" = 'TRIALING') AND (sub."currentPeriodEnd" >= NOW() OR sub."isManual" = true) THEN
                 CASE
                   WHEN sub."planType" = 'PREMIUM' THEN 3
                   WHEN sub."planType" = 'GOLD' THEN 2


### PR DESCRIPTION
Olá! Implementei as melhorias solicitadas no gerenciamento de trials manuais e na visualização de dados para o administrador.

### Alterações Principais:
1.  **Reconhecimento de Trial:** Atualizei o `AuthService` para incluir os dados de assinatura no login. Agora, o front-end e os guards terão acesso imediato ao status `isManual` e `subscriptionStatus`.
2.  **Dados Completos para Admin:** O endpoint `GET /admin/partner-suppliers` agora retorna muito mais informação, incluindo detalhes da assinatura, contagem de produtos e eventos da loja, e dados detalhados do usuário.
3.  **Validade do Trial Manual:** Ajustei a lógica de ranking e listagem de lojas (`StoreService.findAll`) para que assinaturas com `isManual: true` sejam consideradas válidas sempre que estiverem com status `ACTIVE` ou `TRIALING`, ignorando a data de expiração ou garantindo que o trial manual funcione como esperado.
4.  **Gestão de Trial:**
    *   **Bloqueio de duplicidade:** Agora o sistema impede que um novo trial manual seja concedido se o parceiro já possuir ou tiver utilizado um (`isManual: true`).
    *   **Cancelamento:** Adicionei o endpoint `PATCH /admin/cancel-trial/:id` para que o administrador possa revogar um trial manual imediatamente.

### Prompt para o Front-end Admin:
Conforme solicitado, aqui está um prompt que você pode enviar para a equipe de front-end (ou usar em um gerador de código) para ajustar a interface:

> "Preciso atualizar a tela de listagem e detalhes de Fornecedores Parceiros no Admin. O backend agora retorna o objeto `subscription` dentro de `partnerSupplier`.
> 
> 1. **Visualização:** Exiba o status da assinatura (`subscriptionStatus`), o tipo de plano (`planType`) e a data de validade (`currentPeriodEnd`). Se `isManual` for true, destaque como 'Trial Manual'.
> 2. **Gestão de Trial:** 
>    - Adicione um botão 'Cancelar Trial' que chama o endpoint `PATCH /admin/cancel-trial/{partnerSupplierId}`. Este botão só deve aparecer se `subscription.isManual` for true e o status não for `CANCELED`.
>    - No formulário de 'Conceder Trial', se o parceiro já tiver `subscription.isManual === true`, desabilite a opção e exiba uma mensagem: 'Este parceiro já utilizou o período de trial manual'.
> 3. **Métricas:** Use os campos `store._count.products` e `store._count.events` para exibir a quantidade de produtos e eventos que cada fornecedor possui diretamente na listagem."

---
*PR created automatically by Jules for task [18121705366231052365](https://jules.google.com/task/18121705366231052365) started by @higoruserevi*