### PR TITLE
Change Subscription to 1:N Relation

### DIFF
--- a/src/admin/admin.service.spec.ts
+++ b/src/admin/admin.service.spec.ts
@@ -23,7 +23,7 @@ describe('AdminService', () => {
         update: jest.fn(),
       },
       subscription: {
-        upsert: jest.fn(),
+        create: jest.fn(),
       },
     };
 
@@ -97,17 +97,16 @@ describe('AdminService', () => {
       (prismaService.partnerSupplier.findUnique as jest.Mock).mockResolvedValue({
         id: partnerSupplierId,
       });
-      (prismaService.subscription.upsert as jest.Mock).mockResolvedValue({
+      (prismaService.subscription.create as jest.Mock).mockResolvedValue({
         partnerSupplierId,
         subscriptionStatus: 'TRIALING',
       });
 
       const result = await service.grantTrial(partnerSupplierId, dto);
 
-      expect(prismaService.subscription.upsert).toHaveBeenCalledWith(
+      expect(prismaService.subscription.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { partnerSupplierId },
-          update: expect.objectContaining({
+          data: expect.objectContaining({
             subscriptionStatus: 'TRIALING',
             planType: 'PREMIUM',
             isManual: true,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -12,6 +12,7 @@ import { VerifyResetCodeDto } from './dto/verify-reset-code.dto';
 import { MailService } from '../mail/mail.service';
 import { getUsername } from '../ultis';
 import { ResetPasswordDto } from './dto/reset-password.dto';
+import { getActiveSubscription } from 'src/ultis/subscription.util';
 
 @Injectable()
 export class AuthService {
@@ -29,7 +30,7 @@ export class AuthService {
       },
       include: {
         partnerSupplier: {
-          include: { subscription: true },
+          include: { subscriptions: true },
         },
         professional: {
           include: { profession: true },
@@ -44,6 +45,9 @@ export class AuthService {
     }
 
     if (user.partnerSupplier) {
+      (user as any).partnerSupplier.subscription = getActiveSubscription(
+        user.partnerSupplier.subscriptions,
+      );
       if (user.partnerSupplier.status === 'PENDING') {
         throw new ForbiddenException(
           'Cadastro pendente de aprovação. \nVocê receberá um email assim que o processo for concluído.',

--- a/src/prisma/migrations/20251213000000_change_subscription_to_1_n/migration.sql
+++ b/src/prisma/migrations/20251213000000_change_subscription_to_1_n/migration.sql
@@ -1,0 +1,5 @@
+-- DropIndex
+DROP INDEX "Subscription_partnerSupplierId_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Subscription_subscriptionId_key" ON "Subscription"("subscriptionId");

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -84,7 +84,7 @@ model PartnerSupplier {
   user         User?         @relation("UserPartner")
   store        Store?
   storeId      String?       @unique
-  subscription Subscription?
+  subscriptions Subscription[]
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }
@@ -410,9 +410,9 @@ model PasswordResetCode {
 model Subscription {
   id                 String             @id @default(cuid())
   partnerSupplier    PartnerSupplier    @relation(fields: [partnerSupplierId], references: [id])
-  partnerSupplierId  String             @unique
+  partnerSupplierId  String
   stripeCustomerId   String?
-  subscriptionId     String?
+  subscriptionId     String?            @unique
   subscriptionStatus SubscriptionStatus
   planType           String
   currentPeriodEnd   DateTime

--- a/src/subscription/subscription.service.ts
+++ b/src/subscription/subscription.service.ts
@@ -53,10 +53,9 @@ export class SubscriptionsService {
 
     await this.prisma.subscription.upsert({
       where: {
-        partnerSupplierId: partnerSupplier.id,
+        subscriptionId,
       },
       update: {
-        subscriptionId,
         subscriptionStatus: status.toUpperCase(),
         planType: getPlanType(plan.amount.toString()),
         currentPeriodEnd: periodEnd,

--- a/src/ultis/subscription.util.ts
+++ b/src/ultis/subscription.util.ts
@@ -7,3 +7,40 @@ export function getPlanType(amount: string) {
     return 'PREMIUM';
   }
 }
+
+export function getActiveSubscription(subscriptions: any[]) {
+  if (!subscriptions || subscriptions.length === 0) return null;
+
+  const activeSubs = subscriptions.filter((sub) => {
+    const isActive =
+      sub.subscriptionStatus === 'ACTIVE' ||
+      sub.subscriptionStatus === 'TRIALING';
+    const isNotExpired =
+      new Date(sub.currentPeriodEnd) >= new Date() || sub.isManual;
+    return isActive && isNotExpired;
+  });
+
+  if (activeSubs.length === 0) return null;
+
+  const planPriority: Record<string, number> = {
+    PREMIUM: 3,
+    GOLD: 2,
+    SILVER: 1,
+  };
+
+  activeSubs.sort((a, b) => {
+    const priorityA = planPriority[a.planType] || 0;
+    const priorityB = planPriority[b.planType] || 0;
+
+    if (priorityA !== priorityB) {
+      return priorityB - priorityA;
+    }
+
+    return (
+      new Date(b.currentPeriodEnd).getTime() -
+      new Date(a.currentPeriodEnd).getTime()
+    );
+  });
+
+  return activeSubs[0];
+}


### PR DESCRIPTION
The subscription system was modified from a 1:1 relationship to a 1:N relationship between `PartnerSupplier` and `Subscription`. This allows for historical tracking of subscriptions while maintaining logic to identify the currently active one. The change includes schema updates, service logic updates, and a priority-based selection mechanism for active subscriptions. Backward compatibility is maintained by mapping the active subscription to a singular `subscription` property in service responses.

---
*PR created automatically by Jules for task [13896742153972341352](https://jules.google.com/task/13896742153972341352) started by @higoruserevi*