### PR TITLE
Fix Null Constraint Violation on Event Address

### DIFF
--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -339,6 +339,23 @@ export class AdminService {
   }
 
   async createEvent(dto: CreateEventDto) {
+    let addressData: any;
+
+    if (dto.address) {
+      addressData = { create: dto.address };
+    } else {
+      const store = await this.prisma.store.findUnique({
+        where: { id: dto.storeId },
+        select: { addressId: true },
+      });
+
+      if (!store) {
+        throw new NotFoundException('Loja não encontrada');
+      }
+
+      addressData = { connect: { id: store.addressId } };
+    }
+
     return this.prisma.event.create({
       data: {
         name: dto.name,
@@ -350,9 +367,7 @@ export class AdminService {
         store: {
           connect: { id: dto.storeId },
         },
-        address: {
-          create: dto.address,
-        },
+        address: addressData,
       },
       include: {
         address: true,

--- a/src/event/event.service.ts
+++ b/src/event/event.service.ts
@@ -13,7 +13,24 @@ export class EventService {
   constructor(private prisma: PrismaService) {}
 
   async create(dto: CreateEventDto) {
-    await this.prisma.event.create({
+    let addressData: any;
+
+    if (dto.address) {
+      addressData = { create: dto.address };
+    } else {
+      const store = await this.prisma.store.findUnique({
+        where: { id: dto.storeId },
+        select: { addressId: true },
+      });
+
+      if (!store) {
+        throw new NotFoundException('Loja não encontrada');
+      }
+
+      addressData = { connect: { id: store.addressId } };
+    }
+
+    return await this.prisma.event.create({
       data: {
         name: dto.name,
         description: dto.description,
@@ -24,9 +41,7 @@ export class EventService {
         store: {
           connect: { id: dto.storeId },
         },
-        address: {
-          create: dto.address,
-        },
+        address: addressData,
       },
     });
   }


### PR DESCRIPTION
Resolved a 'PrismaClientKnownRequestError' (Null constraint violation on 'addressId') occurring during event creation. 

Modified 'AdminService.createEvent' and 'EventService.create' to:
1. Check if an address is provided in the DTO.
2. If not, fetch the 'addressId' from the associated store.
3. Use the store's address as a fallback, ensuring the 'addressId' field in the 'Event' model is always populated.
4. Added a 'NotFoundException' check to ensure the store exists before proceeding.

Verified the fix by running existing 'AdminService' tests and manually reviewing the service implementations.

---
*PR created automatically by Jules for task [8511400727126009951](https://jules.google.com/task/8511400727126009951) started by @higoruserevi*