### PR TITLE
Revise PartnerSupplier Store creation and Event address logic

### DIFF
--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -346,14 +346,15 @@ export class AdminService {
     } else {
       const store = await this.prisma.store.findUnique({
         where: { id: dto.storeId },
-        select: { addressId: true },
+        include: { address: true },
       });
 
-      if (!store) {
-        throw new NotFoundException('Loja não encontrada');
+      if (!store || !store.address) {
+        throw new NotFoundException('Loja ou endereço da loja não encontrado');
       }
 
-      addressData = { connect: { id: store.addressId } };
+      const { id, createdAt, updatedAt, ...addressDetails } = store.address;
+      addressData = { create: addressDetails };
     }
 
     return this.prisma.event.create({

--- a/src/event/event.service.ts
+++ b/src/event/event.service.ts
@@ -20,14 +20,15 @@ export class EventService {
     } else {
       const store = await this.prisma.store.findUnique({
         where: { id: dto.storeId },
-        select: { addressId: true },
+        include: { address: true },
       });
 
-      if (!store) {
-        throw new NotFoundException('Loja não encontrada');
+      if (!store || !store.address) {
+        throw new NotFoundException('Loja ou endereço da loja não encontrado');
       }
 
-      addressData = { connect: { id: store.addressId } };
+      const { id, createdAt, updatedAt, ...addressDetails } = store.address;
+      addressData = { create: addressDetails };
     }
 
     return await this.prisma.event.create({

--- a/src/partner-supplier/partner-supplier.service.ts
+++ b/src/partner-supplier/partner-supplier.service.ts
@@ -49,7 +49,22 @@ export class PartnerSupplierService {
         hashedPassword,
       );
 
-      return { partnerSupplier, user };
+      const store = await tx.store.create({
+        data: {
+          name: dto.tradeName,
+          partnerId: partnerSupplier.id,
+          addressId: user.addressId,
+        },
+      });
+
+      await tx.partnerSupplier.update({
+        where: { id: partnerSupplier.id },
+        data: {
+          storeId: store.id,
+        },
+      });
+
+      return { partnerSupplier, user, store };
     });
   }
 


### PR DESCRIPTION
This change automates the creation of a Store when a Partner Supplier is registered, using the trade name and the user's address. Additionally, it improves the Event creation logic by cloning the associated Store's address instead of just linking to it when no specific address is provided, which prevents side effects on historical event records if the store's address changes later.

---
*PR created automatically by Jules for task [16593289633889665912](https://jules.google.com/task/16593289633889665912) started by @higoruserevi*