### PR TITLE
Deativate Partner Supplier Option

### DIFF
--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -203,4 +203,10 @@ export class AdminController {
   async cancelTrial(@Param('id') id: string) {
     return await this.adminService.cancelManualSubscription(id);
   }
+
+  @UseGuards(AdminGuard)
+  @Delete('partner-supplier/:id')
+  async softDeletePartnerSupplier(@Param('id') id: string) {
+    return await this.adminService.softDeletePartnerSupplier(id);
+  }
 }

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -84,39 +84,82 @@ export class AdminService {
     };
   }
 
-  async deletePartnerSupplier(id: string) {
-    return this.prisma.$transaction(async (tx) => {
-      // Apaga subscription
-      await tx.subscription.deleteMany({
-        where: { partnerSupplierId: id },
-      });
+  async softDeletePartnerSupplier(id: string) {
+    const partner = await this.prisma.partnerSupplier.findUnique({
+      where: { id },
+      include: {
+        user: true,
+        store: true,
+      },
+    });
 
-      // Apaga usuário vinculado
-      await tx.user.deleteMany({
-        where: { partnerSupplierId: id },
-      });
+    if (!partner) {
+      throw new NotFoundException('Fornecedor parceiro não encontrado!');
+    }
 
-      // Apaga endereço vinculado à loja
-      await tx.address.deleteMany({
-        where: {
-          stores: {
-            some: {
-              partnerId: id,
-            },
+    const result = await this.prisma.$transaction(async (tx) => {
+      const timestamp = Date.now();
+
+      // Desativa todos os usuários vinculados
+      if (partner.user) {
+        await tx.user.update({
+          where: { id: partner.user.id },
+          data: {
+            isDeleted: true,
+            deletedAt: new Date(),
+            email: `deleted_${timestamp}_${partner.user.email}`,
           },
+        });
+      }
+
+      await tx.user.updateMany({
+        where: { partnerSupplierId: id, isDeleted: false },
+        data: {
+          isDeleted: true,
+          deletedAt: new Date(),
         },
       });
 
-      // Apaga loja
-      await tx.store.deleteMany({
-        where: { partnerId: id },
+      // Cancela assinaturas
+      await tx.subscription.updateMany({
+        where: { partnerSupplierId: id },
+        data: {
+          subscriptionStatus: 'CANCELED',
+        },
       });
 
-      // Finalmente, apaga o PartnerSupplier
-      return tx.partnerSupplier.delete({
+      // Desativa a loja vinculada, se existir
+      if (partner.store) {
+        // Como o modelo Store não possui isDeleted, poderíamos considerar adicionar
+        // ou simplesmente garantir que ela não apareça nos resultados.
+        // Por enquanto, seguiremos a recomendação do review de "desativar".
+        // Se não houver campo isActive/isDeleted na Store, a própria desativação do Partner
+        // já deve filtrar na maioria das queries (visto em StoreService.findAll).
+      }
+
+      // Desativa o lojista parceiro
+      return tx.partnerSupplier.update({
         where: { id },
+        data: {
+          isDeleted: true,
+          deletedAt: new Date(),
+        },
       });
     });
+
+    // Envia email de notificação após sucesso da transação
+    if (partner.user) {
+      await this.mailService.sendMail(
+        partner.user.email,
+        'Conta de lojista desativada',
+        'conta-excluida.html',
+        {
+          username: getUsername(partner.user),
+        },
+      );
+    }
+
+    return result;
   }
 
   async approvePartnerSupplier(id: string) {

--- a/src/mail/templates/conta-excluida.html
+++ b/src/mail/templates/conta-excluida.html
@@ -1,0 +1,166 @@
+<!--
+* This email was built using Tabular.
+* For more information, visit https://tabular.email
+-->
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" lang="en">
+<head>
+    <title></title>
+    <meta charset="UTF-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <!--[if !mso]>-->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <!--<![endif]-->
+    <meta name="x-apple-disable-message-reformatting" content="" />
+    <meta content="target-densitydpi=device-dpi" name="viewport" />
+    <meta content="true" name="HandheldFriendly" />
+    <meta content="width=device-width" name="viewport" />
+    <meta name="format-detection" content="telephone=no, date=no, address=no, email=no, url=no" />
+    <style type="text/css">
+        table {
+            border-collapse: separate;
+            table-layout: fixed;
+            mso-table-lspace: 0pt;
+            mso-table-rspace: 0pt
+        }
+        table td {
+            border-collapse: collapse
+        }
+        .ExternalClass {
+            width: 100%
+        }
+        .ExternalClass,
+        .ExternalClass p,
+        .ExternalClass span,
+        .ExternalClass font,
+        .ExternalClass td,
+        .ExternalClass div {
+            line-height: 100%
+        }
+        body, a, li, p, h1, h2, h3 {
+            -ms-text-size-adjust: 100%;
+            -webkit-text-size-adjust: 100%;
+        }
+        html {
+            -webkit-text-size-adjust: none !important
+        }
+        body, #innerTable {
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale
+        }
+        #innerTable img+div {
+            display: none;
+            display: none !important
+        }
+        img {
+            Margin: 0;
+            padding: 0;
+            -ms-interpolation-mode: bicubic
+        }
+        h1, h2, h3, p, a {
+            line-height: inherit;
+            overflow-wrap: normal;
+            white-space: normal;
+            word-break: break-word
+        }
+        a {
+            text-decoration: none
+        }
+        h1, h2, h3, p {
+            min-width: 100%!important;
+            width: 100%!important;
+            max-width: 100%!important;
+            display: inline-block!important;
+            border: 0;
+            padding: 0;
+            margin: 0
+        }
+        a[x-apple-data-detectors] {
+            color: inherit !important;
+            text-decoration: none !important;
+            font-size: inherit !important;
+            font-family: inherit !important;
+            font-weight: inherit !important;
+            line-height: inherit !important
+        }
+        u + #body a {
+            color: inherit;
+            text-decoration: none;
+            font-size: inherit;
+            font-family: inherit;
+            font-weight: inherit;
+            line-height: inherit;
+        }
+        a[href^="mailto"],
+        a[href^="tel"],
+        a[href^="sms"] {
+            color: inherit;
+            text-decoration: none
+        }
+    </style>
+    <style type="text/css">
+        @media (min-width: 481px) {
+            .hd { display: none!important }
+        }
+    </style>
+    <style type="text/css">
+        @media (max-width: 480px) {
+            .hm { display: none!important }
+        }
+    </style>
+    <style type="text/css">
+        @media (max-width: 480px) {
+            .t36,.t41{mso-line-height-alt:0px!important;line-height:0!important;display:none!important}.t37{padding-top:43px!important;border:0!important;border-radius:0!important}.t31{mso-line-height-alt:26px!important;line-height:26px!important}.t17{mso-line-height-alt:25px!important;line-height:25px!important}.t22{text-align:left!important}.t21{vertical-align:top!important;width:600px!important}
+        }
+    </style>
+    <!--[if !mso]>-->
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@500;600&amp;family=Albert+Sans:wght@500&amp;family=Roboto:wght@400&amp;display=swap" rel="stylesheet" type="text/css" />
+    <!--[if !mso]>-->
+    <!--[if mso]>
+    <xml>
+        <o:OfficeDocumentSettings>
+            <o:AllowPNG/>
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+    </xml>
+    <![endif]-->
+</head>
+<body id="body" class="t44" style="min-width:100%;Margin:0px;padding:0px;background-color:#F9F9F9;"><div class="t43" style="background-color:#F9F9F9;"><table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" align="center"><tr><td class="t42" style="font-size:0;line-height:0;mso-line-height-rule:exactly;background-color:#F9F9F9;background-image:none;background-repeat:repeat;background-size:auto;background-position:center top;" valign="top" align="center">
+    <!--[if mso]>
+    <v:background xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false">
+        <v:fill color="#F9F9F9"/>
+    </v:background>
+    <![endif]-->
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" align="center" id="innerTable"><tr><td><div class="t36" style="mso-line-height-rule:exactly;mso-line-height-alt:70px;line-height:70px;font-size:1px;display:block;">&nbsp;&nbsp;</div></td></tr><tr><td align="center">
+        <table class="t40" role="presentation" cellpadding="0" cellspacing="0" style="Margin-left:auto;Margin-right:auto;"><tr><td width="400" class="t39" style="width:400px;">
+            <table class="t38" role="presentation" cellpadding="0" cellspacing="0" width="100%" style="width:100%;"><tr><td class="t37" style="border:1px solid #CECECE;overflow:hidden;background-color:#FFFFFF;padding:50px 40px 40px 40px;border-radius:20px 20px 20px 20px;"><table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="width:100% !important;"><tr><td align="center">
+                <table class="t4" role="presentation" cellpadding="0" cellspacing="0" style="Margin-left:auto;Margin-right:auto;"><tr><td width="60" class="t3" style="width:60px;">
+                    <table class="t2" role="presentation" cellpadding="0" cellspacing="0" width="100%" style="width:100%;"><tr><td class="t1"><a href="#" style="font-size:0px;" target="_blank"><img class="t0" style="display:block;border:0;height:auto;width:100%;Margin:0;max-width:100%;" width="60" height="46.40159045725646" alt="" src="https://385ec840-6ac0-4779-bbcd-fb63463429b8.b-cdn.net/e/6d6e9de2-654e-4e9c-a0de-4ddab4dbe2c6/9250076c-9cdb-4ffc-ba36-c9cea6d927fb.png"/></a></td></tr></table>
+                </td></tr></table>
+            </td></tr><tr><td><div class="t5" style="mso-line-height-rule:exactly;mso-line-height-alt:13px;line-height:13px;font-size:1px;display:block;">&nbsp;&nbsp;</div></td></tr><tr><td align="center">
+                <table class="t10" role="presentation" cellpadding="0" cellspacing="0" style="Margin-left:auto;Margin-right:auto;"><tr><td width="318" class="t9" style="width:339px;">
+                    <table class="t8" role="presentation" cellpadding="0" cellspacing="0" width="100%" style="width:100%;"><tr><td class="t7"><h1 class="t6" style="margin:0;Margin:0;font-family:Inter,BlinkMacSystemFont,Segoe UI,Helvetica Neue,Arial,sans-serif;line-height:28px;font-weight:600;font-style:normal;font-size:24px;text-decoration:none;text-transform:none;letter-spacing:-1.2px;direction:ltr;color:#111111;text-align:center;mso-line-height-rule:exactly;mso-text-raise:1px;">Olá, {{username}}</h1></td></tr></table>
+                </td></tr></table>
+            </td></tr><tr><td><div class="t12" style="mso-line-height-rule:exactly;mso-line-height-alt:17px;line-height:17px;font-size:1px;display:block;">&nbsp;&nbsp;</div></td></tr><tr><td align="center">
+                <table class="t16" role="presentation" cellpadding="0" cellspacing="0" style="Margin-left:auto;Margin-right:auto;"><tr><td width="308" class="t15" style="width:308px;">
+                    <table class="t14" role="presentation" cellpadding="0" cellspacing="0" width="100%" style="width:100%;"><tr><td class="t13"><p class="t11" style="margin:0;Margin:0;font-family:Inter,BlinkMacSystemFont,Segoe UI,Helvetica Neue,Arial,sans-serif;line-height:22px;font-weight:500;font-style:normal;font-size:15px;text-decoration:none;text-transform:none;letter-spacing:-0.6px;direction:ltr;color:#424040;text-align:center;mso-line-height-rule:exactly;mso-text-raise:2px;">Sua conta de lojista parceiro foi desativada pela administração da UP Connection.</p></td></tr></table>
+                    <div style="mso-line-height-rule:exactly;mso-line-height-alt:16px;line-height:16px;font-size:1px;display:block;">&nbsp;&nbsp;</div>
+                    <table class="t14" role="presentation" cellpadding="0" cellspacing="0" width="100%" style="width:100%;"><tr><td class="t13"><p class="t11" style="margin:0;Margin:0;font-family:Inter,BlinkMacSystemFont,Segoe UI,Helvetica Neue,Arial,sans-serif;line-height:22px;font-weight:500;font-style:normal;font-size:15px;text-decoration:none;text-transform:none;letter-spacing:-0.6px;direction:ltr;color:#424040;text-align:center;mso-line-height-rule:exactly;mso-text-raise:2px;">Se você acredita que isso foi um erro ou deseja mais informações, entre em contato conosco.</p></td></tr></table>
+                </td></tr></table>
+            </td></tr><tr><td><div class="t17" style="mso-line-height-rule:exactly;mso-line-height-alt:20px;line-height:20px;font-size:1px;display:block;">&nbsp;&nbsp;</div></td></tr><tr><td align="center">
+                <table class="t29" role="presentation" cellpadding="0" cellspacing="0" style="Margin-left:auto;Margin-right:auto;"><tr><td width="318" class="t28" style="width:600px;">
+                    <table class="t27" role="presentation" cellpadding="0" cellspacing="0" width="100%" style="width:100%;"><tr><td class="t26"><div class="t25" style="width:100%;text-align:left;"><div class="t24" style="display:inline-block;"><table class="t23" role="presentation" cellpadding="0" cellspacing="0" align="left" valign="top">
+                        <tr class="t22"><td></td><td class="t21" width="318" valign="top">
+                            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" class="t20" style="width:100%;"><tr><td class="t19"><div class="t18" style="margin:0;Margin:0;font-family:Roboto,BlinkMacSystemFont,Segoe UI,Helvetica Neue,Arial,sans-serif;line-height:22px;font-weight:400;font-style:normal;font-size:22px;text-decoration:none;text-transform:none;direction:ltr;color:#333333;text-align:center;mso-line-height-rule:exactly;mso-text-raise:-1px;">👋</div></td></tr></table>
+                        </td>
+                            <td></td></tr>
+                    </table></div></div></td></tr></table>
+                </td></tr></table>
+            </td></tr><tr><td><div class="t31" style="mso-line-height-rule:exactly;mso-line-height-alt:30px;line-height:30px;font-size:1px;display:block;">&nbsp;&nbsp;</div></td></tr><tr><td align="center">
+                <table class="t35" role="presentation" cellpadding="0" cellspacing="0" style="Margin-left:auto;Margin-right:auto;"><tr><td width="318" class="t34" style="width:420px;">
+                    <table class="t33" role="presentation" cellpadding="0" cellspacing="0" width="100%" style="width:100%;"><tr><td class="t32" style="overflow:hidden;background-color:#F2EFF3;padding:20px 30px 20px 30px;border-radius:8px 8px 8px 8px;"><p class="t30" style="margin:0;Margin:0;font-family:Albert Sans,BlinkMacSystemFont,Segoe UI,Helvetica Neue,Arial,sans-serif;line-height:18px;font-weight:500;font-style:normal;font-size:12px;text-decoration:none;text-transform:none;direction:ltr;color:#84828E;text-align:center;mso-line-height-rule:exactly;mso-text-raise:2px;">Atenciosamente, Equipe UP Connection</p></td></tr></table>
+                </td></tr></table>
+            </td></tr></table></td></tr></table>
+        </td></tr></table>
+    </td></tr><tr><td><div class="t41" style="mso-line-height-rule:exactly;mso-line-height-alt:70px;line-height:70px;font-size:1px;display:block;">&nbsp;&nbsp;</div></td></tr></table></td></tr></table></div><div class="gmail-fix" style="display: none; white-space: nowrap; font: 15px courier; line-height: 0;">&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;</div></body>
+</html>

--- a/src/store/store.service.ts
+++ b/src/store/store.service.ts
@@ -164,7 +164,7 @@ export class StoreService {
         FROM "Store" s
                INNER JOIN "PartnerSupplier" ps ON s."partnerId" = ps.id
                LEFT JOIN "Subscription" sub ON ps.id = sub."partnerSupplierId"
-        WHERE 1=1
+        WHERE ps."isDeleted" = false
         ${
           search
             ? Prisma.sql`AND (


### PR DESCRIPTION
This change adds a new administrative endpoint that allows for the soft deletion (deactivation) of partner suppliers. When a partner is deactivated, their account and all associated users are marked as deleted, their active subscriptions are canceled, and a notification email is sent to the primary account owner. Additionally, stores belonging to deactivated partners are now filtered out of the general store listings.

---
*PR created automatically by Jules for task [11477420940472516862](https://jules.google.com/task/11477420940472516862) started by @higoruserevi*