### PR TITLE
Add professional listing endpoint for Admin CRM

### DIFF
--- a/src/admin/admin.controller.spec.ts
+++ b/src/admin/admin.controller.spec.ts
@@ -23,6 +23,7 @@ describe('AdminController', () => {
           useValue: {
             rejectPartnerSupplier: jest.fn(),
             grantTrial: jest.fn(),
+            findAllProfessionals: jest.fn(),
           },
         },
         AdminBenefitsService,
@@ -61,5 +62,13 @@ describe('AdminController', () => {
     await controller.grantTrial(id, dto);
 
     expect(adminService.grantTrial).toHaveBeenCalledWith(id, dto);
+  });
+
+  it('should call adminService.findAllProfessionals with correct arguments', async () => {
+    const dto: any = { page: 1, limit: 10 };
+
+    await controller.findAllProfessionals(dto);
+
+    expect(adminService.findAllProfessionals).toHaveBeenCalledWith(dto);
   });
 });

--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -26,6 +26,7 @@ import { UpdateBenefitDto } from '../benefits/dto/update-benefit.dto';
 import { CreateBenefitDTO } from '../benefits/dto/create-benefit.dto';
 import { AdminBenefitsService } from './admin-benefit.service';
 import { GrantTrialDto } from './dto/grant-trial.dto';
+import { FindAllProfessionalsDto } from './dto/find-all-professionals.dto';
 
 @Controller('admin')
 export class AdminController {
@@ -37,6 +38,12 @@ export class AdminController {
   @Post('login')
   adminLogin(@Body() loginDto: LoginDto) {
     return this.adminService.adminLogin(loginDto);
+  }
+
+  @UseGuards(AdminGuard)
+  @Get('professionals')
+  findAllProfessionals(@Query() dto: FindAllProfessionalsDto) {
+    return this.adminService.findAllProfessionals(dto);
   }
 
   @UseGuards(AdminGuard)

--- a/src/admin/admin.service.spec.ts
+++ b/src/admin/admin.service.spec.ts
@@ -25,6 +25,10 @@ describe('AdminService', () => {
       subscription: {
         upsert: jest.fn(),
       },
+      professional: {
+        count: jest.fn(),
+        findMany: jest.fn(),
+      },
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -85,6 +89,55 @@ describe('AdminService', () => {
       expect(prismaService.partnerSupplier.update).toHaveBeenCalledWith({
         where: { id: 'partner-id' },
         data: expect.objectContaining({ status: 'REJECTED' }),
+      });
+    });
+  });
+
+  describe('findAllProfessionals', () => {
+    it('should return a list of professionals with pagination metadata', async () => {
+      const dto = { page: 1, limit: 10 };
+      const mockProfessionals = [{ id: '1', name: 'Pro 1' }];
+      const mockCount = 1;
+
+      (prismaService.professional.count as jest.Mock).mockResolvedValue(mockCount);
+      (prismaService.professional.findMany as jest.Mock).mockResolvedValue(mockProfessionals);
+
+      const result = await service.findAllProfessionals(dto);
+
+      expect(prismaService.professional.count).toHaveBeenCalled();
+      expect(prismaService.professional.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          skip: 0,
+          take: 10,
+        }),
+      );
+      expect(result).toEqual({
+        data: mockProfessionals,
+        meta: {
+          total: mockCount,
+          page: 1,
+          limit: 10,
+          totalPages: 1,
+        },
+      });
+    });
+
+    it('should apply filters correctly', async () => {
+      const dto = { search: 'John', level: 'GOLD' as any, verified: true };
+
+      (prismaService.professional.count as jest.Mock).mockResolvedValue(0);
+      (prismaService.professional.findMany as jest.Mock).mockResolvedValue([]);
+
+      await service.findAllProfessionals(dto);
+
+      expect(prismaService.professional.count).toHaveBeenCalledWith({
+        where: expect.objectContaining({
+          level: 'GOLD',
+          verified: true,
+          OR: expect.arrayContaining([
+            { name: { contains: 'John', mode: 'insensitive' } },
+          ]),
+        }),
       });
     });
   });

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -18,6 +18,7 @@ import { UpdateRecommendedProfessionalDto } from 'src/recommended-professional/d
 import { UpdateEventDto } from 'src/event/dto/update-event.dto';
 import { PointsService } from 'src/points/points.service';
 import { GrantTrialDto } from './dto/grant-trial.dto';
+import { FindAllProfessionalsDto } from './dto/find-all-professionals.dto';
 
 @Injectable()
 export class AdminService {
@@ -27,6 +28,90 @@ export class AdminService {
     private readonly jwtService: JwtService,
     private readonly pointsService: PointsService,
   ) {}
+
+  async findAllProfessionals(dto: FindAllProfessionalsDto) {
+    const {
+      page = 1,
+      limit = 10,
+      search,
+      level,
+      professionId,
+      verified,
+      orderBy = 'createdAt',
+      order = 'desc',
+    } = dto;
+
+    const skip = (page - 1) * limit;
+
+    const where: any = {
+      user: {
+        isDeleted: false,
+      },
+    };
+
+    if (search) {
+      where.OR = [
+        { name: { contains: search, mode: 'insensitive' } },
+        { user: { email: { contains: search, mode: 'insensitive' } } },
+        { document: { contains: search, mode: 'insensitive' } },
+        { phone: { contains: search, mode: 'insensitive' } },
+      ];
+    }
+
+    if (level) {
+      where.level = level;
+    }
+
+    if (professionId) {
+      where.professionId = professionId;
+    }
+
+    if (verified !== undefined) {
+      where.verified = verified;
+    }
+
+    const [total, data] = await Promise.all([
+      this.prisma.professional.count({ where }),
+      this.prisma.professional.findMany({
+        where,
+        skip,
+        take: limit,
+        include: {
+          user: {
+            select: {
+              id: true,
+              email: true,
+              profileImage: true,
+              createdAt: true,
+              address: true,
+            },
+          },
+          profession: true,
+          social: true,
+          _count: {
+            select: {
+              eventRegistrations: true,
+              workshops: true,
+              redemptions: true,
+            },
+          },
+        },
+        orderBy: {
+          [orderBy]: order,
+        },
+      }),
+    ]);
+
+    return {
+      data,
+      meta: {
+        total,
+        page,
+        limit,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
 
   async findAllPartnerSuppliers() {
     return this.prisma.partnerSupplier.findMany({

--- a/src/admin/dto/find-all-professionals.dto.ts
+++ b/src/admin/dto/find-all-professionals.dto.ts
@@ -1,0 +1,48 @@
+import { IsOptional, IsInt, IsString, IsEnum, IsBoolean, Min, IsIn } from 'class-validator';
+import { Transform } from 'class-transformer';
+import { ProfessionalLevel } from '@prisma/client';
+
+export class FindAllProfessionalsDto {
+  @IsOptional()
+  @Transform(({ value }) => value === undefined ? undefined : parseInt(value))
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Transform(({ value }) => value === undefined ? undefined : parseInt(value))
+  @IsInt()
+  @Min(1)
+  limit?: number = 10;
+
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @IsOptional()
+  @IsEnum(ProfessionalLevel)
+  level?: ProfessionalLevel;
+
+  @IsOptional()
+  @IsString()
+  professionId?: string;
+
+  @IsOptional()
+  @Transform(({ value }) => {
+    if (value === 'true' || value === true) return true;
+    if (value === 'false' || value === false) return false;
+    return undefined;
+  })
+  @IsBoolean()
+  verified?: boolean;
+
+  @IsOptional()
+  @IsString()
+  @IsIn(['name', 'createdAt', 'points', 'level'])
+  orderBy?: string = 'createdAt';
+
+  @IsOptional()
+  @IsString()
+  @IsIn(['asc', 'desc'])
+  order?: 'asc' | 'desc' = 'desc';
+}


### PR DESCRIPTION
This PR implements a new endpoint for the admin panel to list professionals, serving as a basis for a mini CRM. The endpoint is scalable, supporting pagination, filtering, and sorting. It returns detailed information for each professional, including their user account, profession, social media, and counts of their activities (event registrations, workshops, redemptions).

Endpoint: `GET /admin/professionals`
Query Parameters:
- `page` (number, optional, default: 1)
- `limit` (number, optional, default: 10)
- `search` (string, optional): Searches in name, email, document, and phone.
- `level` (BRONZE | SILVER | GOLD | PLATINUM, optional)
- `professionId` (string, optional)
- `verified` (boolean, optional)
- `orderBy` ('name' | 'createdAt' | 'points' | 'level', optional, default: 'createdAt')
- `order` ('asc' | 'desc', optional, default: 'desc')

The response includes the professional data and pagination metadata.

---
*PR created automatically by Jules for task [14078423951994219729](https://jules.google.com/task/14078423951994219729) started by @higoruserevi*