### PR TITLE
Add Points History Endpoint for Professionals

### DIFF
--- a/src/points/points.controller.spec.ts
+++ b/src/points/points.controller.spec.ts
@@ -1,18 +1,52 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { PointsController } from './points.controller';
+import { PointsService } from './points.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 describe('PointsController', () => {
   let controller: PointsController;
+  let pointsService: PointsService;
+
+  const mockPointsService = {
+    getHistoryByUserEmail: jest.fn(),
+  };
+
+  const mockJwtAuthGuard = {
+    canActivate: jest.fn(() => true),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [PointsController],
-    }).compile();
+      providers: [
+        { provide: PointsService, useValue: mockPointsService },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue(mockJwtAuthGuard)
+      .compile();
 
     controller = module.get<PointsController>(PointsController);
+    pointsService = module.get<PointsService>(PointsService);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('getHistory', () => {
+    it('should call getHistoryByUserEmail with the user email', async () => {
+      const mockUser = { email: 'test@example.com' };
+      const mockHistory = [
+        { id: '1', value: 10, operation: 'ADD', source: 'TEST', createdAt: new Date() },
+      ];
+
+      (pointsService.getHistoryByUserEmail as jest.Mock).mockResolvedValue(mockHistory);
+
+      const result = await controller.getHistory(mockUser, 20);
+
+      expect(pointsService.getHistoryByUserEmail).toHaveBeenCalledWith('test@example.com', 20);
+      expect(result).toEqual(mockHistory);
+    });
   });
 });

--- a/src/points/points.controller.ts
+++ b/src/points/points.controller.ts
@@ -1,4 +1,20 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, UseGuards, Query, ParseIntPipe } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { PointsService } from './points.service';
 
 @Controller('points')
-export class PointsController {}
+@UseGuards(JwtAuthGuard)
+export class PointsController {
+  constructor(
+    private readonly pointsService: PointsService,
+  ) {}
+
+  @Get('history')
+  async getHistory(
+    @CurrentUser() user: any,
+    @Query('limit', new ParseIntPipe({ optional: true })) limit?: number,
+  ) {
+    return this.pointsService.getHistoryByUserEmail(user.email, limit);
+  }
+}

--- a/src/points/points.module.ts
+++ b/src/points/points.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { PointsController } from './points.controller';
 import { PointsService } from './points.service';
 import { PrismaModule } from 'src/prisma/prisma.module';
+import { AuthModule } from 'src/auth/auth.module';
 
 @Module({
   controllers: [PointsController],
   providers: [PointsService],
-  imports: [PrismaModule],
+  imports: [PrismaModule, AuthModule],
   exports: [PointsService],
 })
 export class PointsModule {}

--- a/src/points/points.service.spec.ts
+++ b/src/points/points.service.spec.ts
@@ -1,18 +1,65 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { PointsService } from './points.service';
+import { PrismaService } from 'src/prisma/prisma.service';
+import { PointOperation } from '@prisma/client';
 
 describe('PointsService', () => {
   let service: PointsService;
+  let prisma: PrismaService;
+
+  const mockPrismaService = {
+    professional: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    pointHistory: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+    },
+    $transaction: jest.fn((cb) => cb(mockPrismaService)),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [PointsService],
+      providers: [
+        PointsService,
+        { provide: PrismaService, useValue: mockPrismaService },
+      ],
     }).compile();
 
     service = module.get<PointsService>(PointsService);
+    prisma = module.get<PrismaService>(PrismaService);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('getHistory', () => {
+    it('should return history for a professional', async () => {
+      const professionalId = 'prof-1';
+      const mockHistory = [
+        {
+          id: 'h1',
+          operation: PointOperation.ADD,
+          value: 100,
+          source: 'REFERRAL',
+          professionalId,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ];
+
+      (prisma.pointHistory.findMany as jest.Mock).mockResolvedValue(mockHistory);
+
+      const result = await service.getHistory(professionalId);
+
+      expect(prisma.pointHistory.findMany).toHaveBeenCalledWith({
+        where: { professionalId },
+        orderBy: { createdAt: 'desc' },
+        take: 50,
+      });
+      expect(result).toEqual(mockHistory);
+    });
   });
 });

--- a/src/points/points.service.ts
+++ b/src/points/points.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { PointOperation, Prisma } from '@prisma/client';
 import { PrismaService } from 'src/prisma/prisma.service';
 
@@ -74,5 +74,18 @@ export class PointsService {
     });
 
     return history;
+  }
+
+  async getHistoryByUserEmail(email: string, limit = 50) {
+    const user = await this.prisma.user.findUnique({
+      where: { email },
+      include: { professional: true },
+    });
+
+    if (!user || !user.professional) {
+      throw new NotFoundException('Perfil de profissional não encontrado.');
+    }
+
+    return this.getHistory(user.professional.id, limit);
   }
 }


### PR DESCRIPTION
This PR introduces a new endpoint `GET /points/history` specifically for professional users to track their points history.

### Changes:
1.  **PointsService**:
    *   Added `getHistoryByUserEmail(email: string, limit: number)` to resolve the professional identity from the user's email and fetch their history.
    *   Maintained the existing `getHistory(professionalId: string, limit: number)` logic which sorts by `createdAt` in descending order.
2.  **PointsController**:
    *   Added `@Get('history')` endpoint protected by `JwtAuthGuard`.
    *   Uses `@CurrentUser()` to get the authenticated user's email.
    *   Supports an optional `limit` query parameter via `ParseIntPipe`.
3.  **PointsModule**:
    *   Imported `AuthModule` to enable JWT authentication.
4.  **Testing**:
    *   Updated `PointsController` and `PointsService` specs to cover the new history retrieval logic.

### API Contract:
- **Endpoint**: `GET /points/history`
- **Auth**: `Authorization: Bearer <token>`
- **Query Parameters**: `limit` (optional, default: 50)
- **Response Example**:
  ```json
  [
    {
      "id": "7f880482-972c-4731-901d-55e69e29a39a",
      "operation": "ADD",
      "value": 50,
      "source": "LOGIN",
      "professionalId": "d290f1ee-6c54-4b01-90e6-d701748f0851",
      "createdAt": "2023-10-27T10:00:00.000Z",
      "updatedAt": "2023-10-27T10:00:00.000Z"
    }
  ]
  ```

---
*PR created automatically by Jules for task [3541164485561031281](https://jules.google.com/task/3541164485561031281) started by @higoruserevi*