### PR TITLE
Exclude inactive partner suppliers from admin views

### DIFF
--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -118,6 +118,9 @@ export class AdminService {
 
   async findAllPartnerSuppliers() {
     return this.prisma.partnerSupplier.findMany({
+      where: {
+        isDeleted: false,
+      },
       include: {
         store: {
           include: {
@@ -548,6 +551,11 @@ export class AdminService {
 
   async findStores(order: 'asc' | 'desc' = 'asc') {
     return this.prisma.store.findMany({
+      where: {
+        partner: {
+          isDeleted: false,
+        },
+      },
       include: {
         address: true,
         products: {
@@ -640,12 +648,14 @@ export class AdminService {
       totalRecommendedProfessionals,
       totalPosts,
     ] = await Promise.all([
-      this.prisma.user.count(),
       this.prisma.user.count({
-        where: { professionalId: { not: null } },
+        where: { isDeleted: false },
       }),
       this.prisma.user.count({
-        where: { partnerSupplierId: { not: null } },
+        where: { professionalId: { not: null }, isDeleted: false },
+      }),
+      this.prisma.user.count({
+        where: { partnerSupplierId: { not: null }, isDeleted: false },
       }),
       this.prisma.event.count({
         where: {


### PR DESCRIPTION
This change ensures that partner suppliers who have been soft-deleted (inactivated) are correctly filtered out from the administrative interface. 

Specifically:
- The `findAllPartnerSuppliers` method now includes a `where: { isDeleted: false }` filter.
- The `findStores` method now includes a `where: { partner: { isDeleted: false } }` filter.
- Dashboard statistics for total users, professionals, and partner suppliers now only count non-deleted records.

These changes prevent inactivated partners from continuing to appear in admin lists and metrics.

---
*PR created automatically by Jules for task [16858372848487319010](https://jules.google.com/task/16858372848487319010) started by @higoruserevi*